### PR TITLE
Pipe stderr output when starting container

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -53,6 +53,12 @@ Container.prototype.startAndMountContainer = function(options, finishedCallback)
 		self = this,
 		run = spawn('docker', ['run', '-d', '-v', global.config.path + ':/app/test', '-w', '/app/test', '-it', self.image, '/bin/bash']);
 
+	// Dump errors to the stderr output so they can be seen.
+	run.stderr.on('data', function(data) {
+		console.error('ERROR: ', data.toString());
+		console.error('COMMAND: ', 'docker', 'run', '-d', '-v', global.config.path + ':/app/test', '-w', '/app/test', '-it', self.image, '/bin/bash');
+	});
+
 	// Sanitize and store container ID
 	run.stdout.on('data', function(data) {
 		containerId = data.toString().trim().replace(/[^a-z0-9]/ig, '');


### PR DESCRIPTION
This PR pipes standard error output to the console when a container fails to start along with the launch command.  Useful for debugging why a container wouldn't start.
