### PR TITLE
PR to allow shellCommand and containerLimit

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+[*]
+end_of_line = crlf
+insert_final_newline = true
+
+[*.{js,json}]
+charset = utf-8
+indent_style = tab
+indent_size = 4
+
+[lib/**{.js,json}]
+indent_style = tab
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .idea
 node_modules
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -35,10 +35,12 @@ example `Dockunit.json`:
 
 ```javascript
 {
+  "containerLimit": 1, // Defaults to 1
   "containers": [
     {
       "prettyName": "PHP 5.2 on Ubuntu",
       "image": "user/my-php-image",
+      "shellCommand": "/bin/bash", // Defaults to /bin/bash, needed for images like Alpine
       "beforeScripts": [],
       "testCommand": "phpunit"
     },
@@ -47,6 +49,16 @@ example `Dockunit.json`:
       "image": "user/my-php-image2",
       "beforeScripts": [],
       "testCommand": "phpunit"
+    },
+    {
+      "prettyName": "Server on Apline Node.js 5.9.0",
+      "image": "mhart/alpine-node:5.9.0",
+      "shellCommand": "/bin/ash",
+      "beforeScripts": [
+        "rm -rf node_modules/",
+        "npm install"
+      ],
+      "testCommand": "npm test"
     }
   ]
 }
@@ -239,6 +251,16 @@ an application in Node.js 0.10.x and 0.12.0 using [mocha](http://mochajs.org/):
         "npm install -g mocha"
       ],
       "testCommand": "mocha"
+    },
+    {
+      "prettyName": "Apline Node.js 5.9.0",
+      "image": "mhart/alpine-node:5.9.0",
+      "shellCommand": "/bin/ash",
+      "beforeScripts": [
+        "rm -rf node_modules/",
+        "npm install"
+      ],
+      "testCommand": "npm test"
     }
   ]
 }

--- a/lib/command.js
+++ b/lib/command.js
@@ -11,35 +11,35 @@ var colors = require('colors');
  * Set globals for command
  */
 var setGlobals = exports.setGlobals = function() {
-	/**
-	 * Configuration for dockunit
-	 *
-	 * @type {{path: *, verbose: boolean, help: boolean, version: boolean, container: boolean}}
-	 */
-	global.config = {
-		path: process.cwd(),
-		verbose: false,
-		help: false,
-		version: false,
-		container: false
-	};
+    /**
+     * Configuration for dockunit
+     *
+     * @type {{path: *, verbose: boolean, help: boolean, version: boolean, container: boolean}}
+     */
+    global.config = {
+        path: process.cwd(),
+        verbose: false,
+        help: false,
+        version: false,
+        container: false
+    };
 
-	/**
-	 * Test arguments to pass to test command
-	 */
-	global.testArgs = {};
+    /**
+     * Test arguments to pass to test command
+     */
+    global.testArgs = {};
 
-	/**
-	 * Supported dockunit arguments/options
-	 *
-	 * @type {{du-verbose: boolean, du-container: boolean, help: boolean, version: boolean}}
-	 */
-	global.defaultArgs = {
-		'du-verbose': 0,
-		'du-container': false,
-		help: false,
-		version: false
-	};
+    /**
+     * Supported dockunit arguments/options
+     *
+     * @type {{du-verbose: boolean, du-container: boolean, help: boolean, version: boolean}}
+     */
+    global.defaultArgs = {
+        'du-verbose': 0,
+        'du-container': false,
+        help: false,
+        version: false
+    };
 };
 
 setGlobals();
@@ -48,105 +48,105 @@ setGlobals();
  * Process command line options and arguments
  */
 var processArgs = exports.processArgs = function(args) {
-	global.testArgs = args;
+    global.testArgs = args;
 
-	if (args['du-verbose']) {
-		global.config.verbose = parseInt(args['du-verbose']);
+    if (args['du-verbose']) {
+        global.config.verbose = parseInt(args['du-verbose']);
 
-		if (isNaN(global.config.verbose)) {
-			global.config.verbose = 1;
-		}
-	} else {
-		global.config.verbose = 0;
-	}
+        if (isNaN(global.config.verbose)) {
+            global.config.verbose = 1;
+        }
+    } else {
+        global.config.verbose = 0;
+    }
 
-	if (typeof args['du-container'] !== 'undefined' && parseInt(args['du-container']) >= 0) {
-		global.config.container = parseInt(args['du-container']);
-	}
+    if (typeof args['du-container'] !== 'undefined' && parseInt(args['du-container']) >= 0) {
+        global.config.container = parseInt(args['du-container']);
+    }
 
-	if (args.help) {
-		global.config.help = true;
-	}
+    if (args.help) {
+        global.config.help = true;
+    }
 
 
-	if (args.version) {
-		global.config.version = true;
-	}
+    if (args.version) {
+        global.config.version = true;
+    }
 
-	if (args._.length) {
-		global.config.path = args._[0];
+    if (args._.length) {
+        global.config.path = args._[0];
 
-		// First argument is assumed to be the dockunit path
-		global.testArgs._.shift();
-	}
+        // First argument is assumed to be the dockunit path
+        global.testArgs._.shift();
+    }
 
-	for (var key in global.testArgs) {
-		if (key !== '_' && typeof global.defaultArgs[key] !== 'undefined') {
-			delete global.testArgs[key];
-		}
-	}
+    for (var key in global.testArgs) {
+        if (key !== '_' && typeof global.defaultArgs[key] !== 'undefined') {
+            delete global.testArgs[key];
+        }
+    }
 };
 
 /**
  * Main script command
  */
 exports.execute = function() {
-	var json;
-	processArgs(argv);
+    var json;
+    processArgs(argv);
 
-	if (global.config.help) {
-		var help = '\nUsage:\n'.yellow +
-			'  dockunit <path-to-project-directory> [options]\n' +
-			'\n' +
-			'\nOptions:'.yellow +
-			'\n  --du-verbose'.green + ' Output various lines of status throughout testing' +
-			'\n  --help'.green + ' Display this help text' +
-			'\n  --version'.green + ' Display current version' +
-			'\n';
-		console.log(help);
-		process.exit(0);
-	}
+    if (global.config.help) {
+        var help = '\nUsage:\n'.yellow +
+            '  dockunit <path-to-project-directory> [options]\n' +
+            '\n' +
+            '\nOptions:'.yellow +
+            '\n  --du-verbose'.green + ' Output various lines of status throughout testing' +
+            '\n  --help'.green + ' Display this help text' +
+            '\n  --version'.green + ' Display current version' +
+            '\n';
+        console.log(help);
+        process.exit(0);
+    }
 
-	if (global.config.version) {
-		console.log('\nDockunit ' + packageObject.version + ' by Taylor Lovett\n');
-		process.exit(0);
-	}
+    if (global.config.version) {
+        console.log('\nDockunit ' + packageObject.version + ' by Taylor Lovett\n');
+        process.exit(0);
+    }
 
-	var docker = spawn('docker', []);
+    var docker = spawn('docker', []);
 
-	docker.on('error', function(error) {
-		console.error('\nDocker is not installed or configured properly'.red);
-	});
+    docker.on('error', function(error) {
+        console.error('\nDocker is not installed or configured properly'.red);
+    });
 
-	docker.on('exit', function(code) {
-		try {
-			json = JSON.parse(fs.readFileSync(global.config.path + '/Dockunit.json', 'utf8'));
-		} catch (exception) {
-			console.error('\nCould not parse Dockunit.json'.red);
-			process.exit(255);
-		}
+    docker.on('exit', function(code) {
+        try {
+            json = JSON.parse(fs.readFileSync(global.config.path + '/Dockunit.json', 'utf8'));
+        } catch (exception) {
+            console.error('\nCould not parse Dockunit.json'.red);
+            process.exit(255);
+        }
 
-		var containers = new Containers(json.containers);
+        var containers = new Containers(json.containers);
 
-		containers.run(function(returnCodes) {
-			var errors = 0;
+        containers.run(function(returnCodes) {
+            var errors = 0;
 
-			for (var i = 0; i < returnCodes.length; i++) {
-				if (returnCodes[i] !== 0) {
-					errors++;
-				}
-			}
+            for (var i = 0; i < returnCodes.length; i++) {
+                if (returnCodes[i] !== 0) {
+                    errors++;
+                }
+            }
 
-			if (!returnCodes.length) {
-				console.log(('\nNo containers finished').bgYellow + '\n');
-			} else {
-				if (!errors) {
-					console.log(('\n' + returnCodes.length + ' container(s) passed').bgGreen + '\n');
-				} else {
-					console.error(('\n' + (returnCodes.length - errors) + ' out of ' + returnCodes.length + ' container(s) passed').bgRed + '\n');
-					process.exit(1);
-				}
-			}
-		}, global.config.container);
-	});
+            if (!returnCodes.length) {
+                console.log(('\nNo containers finished').bgYellow + '\n');
+            } else {
+                if (!errors) {
+                    console.log(('\n' + returnCodes.length + ' container(s) passed').bgGreen + '\n');
+                } else {
+                    console.error(('\n' + (returnCodes.length - errors) + ' out of ' + returnCodes.length + ' container(s) passed').bgRed + '\n');
+                    process.exit(1);
+                }
+            }
+        }, global.config.container);
+    });
 };

--- a/lib/command.js
+++ b/lib/command.js
@@ -126,7 +126,7 @@ exports.execute = function() {
             process.exit(255);
         }
 
-        var containers = new Containers(json.containers);
+        var containers = new Containers(json);
 
         containers.run(function(returnCodes) {
             var errors = 0;

--- a/lib/container.js
+++ b/lib/container.js
@@ -6,7 +6,16 @@ var Docker = require('rouster').Docker;
 var async = require('async');
 
 var reformCommand = function(cmd){
-    return cmd.match(/"[^"]+"|'[^']+'|[^ \t]+/g);
+    var res = cmd.match(/"[^"]*"|'[^']*'|[^ \t]+/g);
+    return res.map((cmdStr)=>{
+      if(cmdStr[0]==='\'' && cmdStr[cmdStr.length-1]==='\''){
+        return cmdStr.substr(1, cmdStr.length-2);
+      }
+      if(cmdStr[0]==='"' && cmdStr[cmdStr.length-1]==='"'){
+        return cmdStr.substr(1, cmdStr.length-2);
+      }
+      return cmdStr;
+    });
 }
 
 /**
@@ -103,9 +112,11 @@ Container.prototype.createWorkingCopy = function(finishedCallback) {
  */
 Container.prototype.runBeforeScript = function(script, finishedCallback) {
     var self = this;
-    return self.docker.exec(reformCommand(script), function(err, output){
+    var cmd = reformCommand(script);
+    return self.docker.exec(cmd, function(err, output){
         if(err){
             console.error(('\nFailed to run before script: ' + script).red);
+            console.error(cmd);
             if(err && err.all){
                 console.error(err.all.join(''));
             }
@@ -166,7 +177,8 @@ Container.prototype.runTests = function(finishedCallback) {
         console.log(('\nRunning "' + self.testCommand + testArgString + '" on container '+ self.prettyName).green);
     }
 
-    var exec = self.docker.exec(reformCommand(self.testCommand + testArgString), function(err, output){
+    var cmd = reformCommand(self.testCommand + testArgString);
+    var exec = self.docker.exec(cmd, function(err, output){
         if(err){
             console.error('\nFailed to run test command'.red);
             if(err && err.all){

--- a/lib/container.js
+++ b/lib/container.js
@@ -2,6 +2,11 @@
 
 var spawn = require('child_process').spawn;
 var colors = require('colors');
+var Docker = require('rouster').Docker;
+
+var reformCommand = function(cmd){
+    return cmd.match(/"[^"]+"|'[^']+'|[^ \t]+/g);
+}
 
 /**
  * Initialize a new container
@@ -10,10 +15,16 @@ var colors = require('colors');
  * @constructor
  */
 var Container = function(containerArray) {
-	this.image = containerArray.image;
-	this.testCommand = containerArray.testCommand;
-	this.prettyName = containerArray.prettyName;
-	this.beforeScripts = containerArray.beforeScripts;
+    this.image = containerArray.image;
+    this.testCommand = containerArray.testCommand;
+    this.prettyName = containerArray.prettyName;
+    this.beforeScripts = containerArray.beforeScripts;
+    this.dockerCommand = containerArray.dockerCommand || 'docker';
+    this.shellCommand = containerArray.shellCommand || '/bin/bash';
+    this.docker = new Docker({
+        image: this.image,
+        dockerCommand: this.dockerCommand
+    });
 };
 
 /**
@@ -22,24 +33,32 @@ var Container = function(containerArray) {
  * @param finishedCallback
  */
 Container.prototype.pullImage = function(options, finishedCallback) {
-	var self = this;
+    var self = this;
 
-	if (global.config.verbose) {
-		console.log(('\nPulling docker image: ' + self.image).green);
-	}
+    if (global.config.verbose) {
+        console.log(('\nPulling docker image: ' + self.image).green);
+    }
 
-	var pull = spawn('docker', ['pull', this.image], options);
+    var pull = this.docker.pull(function(err, output){
+        if(err){
+            console.error(('\nCould not pull Docker image: ' + self.image).red);
+            return process.exit(1);
+        }
+        finishedCallback();
+    });
+/*
+    var pull = spawn('docker', ['pull', this.image], options);
 
-	pull.on('exit', function(code) {
-		if (0 === code) {
-			finishedCallback();
-		} else {
-			console.error(('\nCould not pull Docker image: ' + self.image).red);
-			process.exit(1);
-		}
-	});
-
-	return pull;
+    pull.on('exit', function(code) {
+        if (0 === code) {
+            finishedCallback();
+        } else {
+            console.error(('\nCould not pull Docker image: ' + self.image).red);
+            process.exit(1);
+        }
+    });
+*/
+    return pull;
 };
 
 /**
@@ -49,55 +68,73 @@ Container.prototype.pullImage = function(options, finishedCallback) {
  * @param finishedCallback
  */
 Container.prototype.startAndMountContainer = function(options, finishedCallback) {
-	var containerId,
-		self = this,
-		run = spawn('docker', ['run', '-d', '-v', global.config.path + ':/app/test', '-w', '/app/test', '-it', self.image, '/bin/bash']);
+    var self = this;
+    return self.docker.run(self.shellCommand, '-v', global.config.path + ':/app/src', '-w', '/app/test', function(err){
+        if(err){
+            console.error('\nFailed to start and mount Docker container'.red);
+            return process.exit(1);
+        }
+        finishedCallback(self.docker.containerId);
+    });
+/*
+    var containerId,
+        self = this,
+        run = spawn('docker', ['run', '-d', '-v', global.config.path + ':/app/test', '-w', '/app/test', '-it', self.image, '/bin/bash']);
 
-	// Dump errors to the stderr output so they can be seen.
-	run.stderr.on('data', function(data) {
-		console.error('ERROR: ', data.toString());
-		console.error('COMMAND: ', 'docker', 'run', '-d', '-v', global.config.path + ':/app/test', '-w', '/app/test', '-it', self.image, '/bin/bash');
-	});
+    // Dump errors to the stderr output so they can be seen.
+    run.stderr.on('data', function(data) {
+        console.error('ERROR: ', data.toString());
+        console.error('COMMAND: ', 'docker', 'run', '-d', '-v', global.config.path + ':/app/test', '-w', '/app/test', '-it', self.image, '/bin/bash');
+    });
 
-	// Sanitize and store container ID
-	run.stdout.on('data', function(data) {
-		containerId = data.toString().trim().replace(/[^a-z0-9]/ig, '');
-	});
+    // Sanitize and store container ID
+    run.stdout.on('data', function(data) {
+        containerId = data.toString().trim().replace(/[^a-z0-9]/ig, '');
+    });
 
-	run.on('exit', function(code) {
-		if (0 !== code || !containerId) {
-			console.error('\nFailed to start and mount Docker container'.red);
-			process.exit(1);
-		}
+    run.on('exit', function(code) {
+        if (0 !== code || !containerId) {
+            console.error('\nFailed to start and mount Docker container'.red);
+            process.exit(1);
+        }
 
-		finishedCallback(containerId);
-	});
-
-	return run;
+        finishedCallback(containerId);
+    });
+    return run;
+*/
 };
 
 /**
- * Create a copy of mounted files for later
+ * Create a copy of mounted files for testing
  *
  * @param options
  * @param containerId
  * @param finishedCallback
  */
-Container.prototype.backupFiles = function(options, containerId, finishedCallback) {
+Container.prototype.createWorkingCopy = function(options, containerId, finishedCallback) {
 
-	if (global.config.verbose) {
-		console.log(('\nBacking up volume files on container ' + this.prettyName).green);
-	}
+    if (global.config.verbose) {
+        console.log(('\nBacking up volume files on container ' + this.prettyName).green);
+    }
 
-	var exec = spawn('sh', ['-c', 'docker exec ' + containerId + ' bash + -c "source ~/.bashrc && cp -p -r /app/test /app/backup"']).on('exit', function(code) {
-		if (code !== 0) {
-			console.error('\nFailed to backup up files'.red);
-		}
+    var exec = this.docker.exec('cp', '-R', '/app/src/.', '/app/test', function(err, output){
+        if(err){
+            console.error('\nFailed to create working copy'.red);
+            return process.exit(1);
+        }
+        finishedCallback(output.code);
+    });
+/*
+    var exec = spawn('sh', ['-c', 'docker exec ' + containerId + ' bash + -c "source ~/.bashrc && cp -p -r /app/test /app/backup"']).on('exit', function(code) {
+        if (code !== 0) {
+            console.error('\nFailed to backup up files'.red);
+        }
 
-		finishedCallback(code);
-	});
+        finishedCallback(code);
+    });
 
-	return exec;
+    return exec;
+*/
 };
 
 /**
@@ -109,17 +146,26 @@ Container.prototype.backupFiles = function(options, containerId, finishedCallbac
  * @param finishedCallback
  */
 Container.prototype.runBeforeScript = function(options, index, containerId, finishedCallback) {
-	var self = this;
+    var self = this;
+    self.docker.exec(reformCommand(self.beforeScripts[index]), function(err, output){
+        if(err){
+            console.error(('\nFailed to run before script: ' + self.beforeScripts[index]).red);
+            return process.exit(1);
+        }
+        finishedCallback(index+1, containerId, output.code);
+    });
 
-	spawn('sh', ['-c', 'docker exec ' + containerId + ' ' + self.beforeScripts[index]], options).on('exit', function(code) {
-		if (0 !== code) {
-			console.error(('\nFailed to run before script: ' + self.beforeScripts[index]).red);
-		}
+    /*
+    spawn('sh', ['-c', 'docker exec ' + containerId + ' ' + self.beforeScripts[index]], options).on('exit', function(code) {
+        if (0 !== code) {
+            console.error(('\nFailed to run before script: ' + self.beforeScripts[index]).red);
+        }
 
-		index++;
+        index++;
 
-		finishedCallback(index, containerId, code);
-	});
+        finishedCallback(index, containerId, code);
+    });
+    */
 };
 
 /**
@@ -130,35 +176,35 @@ Container.prototype.runBeforeScript = function(options, index, containerId, fini
  * @param finishedCallback
  */
 Container.prototype.runBeforeScripts = function(options, containerId, finishedCallback) {
-	var self = this;
+    var self = this;
 
-	options = { stdio: ['ignore', 'ignore', 'ignore'] };
+    options = { stdio: ['ignore', 'ignore', 'ignore'] };
 
-	if (global.config.verbose > 1) {
-		options = { stdio: 'inherit' };
-	}
+    if (global.config.verbose > 1) {
+        options = { stdio: 'inherit' };
+    }
 
-	if (global.config.verbose) {
-		console.log('\nRunning before scripts'.green);
-	}
+    if (global.config.verbose) {
+        console.log('\nRunning before scripts'.green);
+    }
 
-	if (!self.beforeScripts.length) {
-		finishedCallback(0);
-	}
+    if (!self.beforeScripts.length) {
+        finishedCallback(0);
+    }
 
-	var nextCallback = function(newIndex, containerId, code) {
-		if (code !== 0) {
-			finishedCallback(1, newIndex);
-		} else {
-			if (newIndex === self.beforeScripts.length) {
-				finishedCallback(code, newIndex);
-			} else {
-				self.runBeforeScript(options, newIndex, containerId, nextCallback);
-			}
-		}
-	};
+    var nextCallback = function(newIndex, containerId, code) {
+        if (code !== 0) {
+            finishedCallback(1, newIndex);
+        } else {
+            if (newIndex === self.beforeScripts.length) {
+                finishedCallback(code, newIndex);
+            } else {
+                self.runBeforeScript(options, newIndex, containerId, nextCallback);
+            }
+        }
+    };
 
-	self.runBeforeScript(options, 0, containerId, nextCallback);
+    self.runBeforeScript(options, 0, containerId, nextCallback);
 };
 
 /**
@@ -169,38 +215,47 @@ Container.prototype.runBeforeScripts = function(options, containerId, finishedCa
  * @param finishedCallback
  */
 Container.prototype.runTests = function(options, containerId, finishedCallback) {
-	var self = this,
-		testArgString = '';
+    var self = this,
+        testArgString = '';
 
-	if (global.testArgs._ && global.testArgs._.length) {
-		testArgString = global.testArgs._.join(' ');
-	}
+    if (global.testArgs._ && global.testArgs._.length) {
+        testArgString = global.testArgs._.join(' ');
+    }
 
-	for (var key in global.testArgs) {
-		if ('_' !== key) {
-			if (typeof global.testArgs[key] !== 'boolean') {
-				testArgString += ' --' + key + '=' + global.testArgs[key];
-			} else {
-				if (global.testArgs[key]) {
-					testArgString += ' --' + key;
-				}
-			}
-		}
-	}
+    for (var key in global.testArgs) {
+        if ('_' !== key) {
+            if (typeof global.testArgs[key] !== 'boolean') {
+                testArgString += ' --' + key + '=' + global.testArgs[key];
+            } else {
+                if (global.testArgs[key]) {
+                    testArgString += ' --' + key;
+                }
+            }
+        }
+    }
 
-	if (global.config.verbose) {
-		console.log(('\nRunning "' + self.testCommand + testArgString + '" on container '+ self.prettyName).green);
-	}
+    if (global.config.verbose) {
+        console.log(('\nRunning "' + self.testCommand + testArgString + '" on container '+ self.prettyName).green);
+    }
 
-	var exec = spawn('sh', ['-c', 'docker exec ' + containerId + ' bash + -c "source ~/.bashrc && ' + self.testCommand + ' ' + testArgString + ' " 1>&2'], { stdio: 'inherit' }).on('exit', function(code) {
-		if (code !== 0) {
-			console.error('\nFailed to run test command'.red);
-		}
+    /*
+    var exec = spawn('sh', ['-c', 'docker exec ' + containerId + ' bash + -c "source ~/.bashrc && ' + self.testCommand + ' ' + testArgString + ' " 1>&2'], { stdio: 'inherit' }).on('exit', function(code) {
+        if (code !== 0) {
+            console.error('\nFailed to run test command'.red);
+        }
 
-		finishedCallback(code);
-	});
+        finishedCallback(code);
+    });
+    */
+    var exec = self.docker.exec(reformCommand(self.testCommand), function(err, output){
+        if(err){
+            console.error('\nFailed to run test command'.red);
+            return finishedCallback(err.code);
+        }
+        finishedCallback(output.code);
+    });
 
-	return exec;
+    return exec;
 };
 
 
@@ -212,20 +267,23 @@ Container.prototype.runTests = function(options, containerId, finishedCallback) 
  * @param finishedCallback
  */
 Container.prototype.cleanupFiles = function(options, containerId, finishedCallback) {
+// No longer needed since we create a working copy to deal with instead of dirtying the local disk
+    return finishedCallback(0);
+/*
+    if (global.config.verbose) {
+        console.log(('\nRestoring volume files on container ' + this.prettyName).green);
+    }
 
-	if (global.config.verbose) {
-		console.log(('\nRestoring volume files on container ' + this.prettyName).green);
-	}
+    var exec = spawn('sh', ['-c', 'docker exec ' + containerId + ' bash + -c "source ~/.bashrc && rm -rf /app/test/* && cp -p -r /app/backup/* /app/test " 1>&2'], { stdio: 'inherit' }).on('exit', function(code) {
+        if (code !== 0) {
+            console.error('\nFailed to restore volume files'.red);
+        }
 
-	var exec = spawn('sh', ['-c', 'docker exec ' + containerId + ' bash + -c "source ~/.bashrc && rm -rf /app/test/* && cp -p -r /app/backup/* /app/test " 1>&2'], { stdio: 'inherit' }).on('exit', function(code) {
-		if (code !== 0) {
-			console.error('\nFailed to restore volume files'.red);
-		}
+        finishedCallback(code);
+    });
 
-		finishedCallback(code);
-	});
-
-	return exec;
+    return exec;
+    */
 };
 
 /**
@@ -236,22 +294,34 @@ Container.prototype.cleanupFiles = function(options, containerId, finishedCallba
  * @param finishedCallback
  */
 Container.prototype.stopContainer = function(options, containerId, finishedCallback) {
-	var self = this;
+    var self = this;
 
-	var stop = spawn('docker', ['stop', containerId], options).on('exit', function(code) {
-		if (0 === code) {
-			if (global.config.verbose) {
-				console.log('\nStopped container'.green);
-			}
+    var stop = self.docker.stop(function(err, output){
+        if(err){
+            console.error(('\nCould not stop container: ' + containerId).red);
+            return process.exit(1);
+        }
+        if (global.config.verbose) {
+            console.log('\nStopped container'.green);
+        }
+        finishedCallback();
+    });
+/*
+    var stop = spawn('docker', ['stop', containerId], options).on('exit', function(code) {
+        if (0 === code) {
+            if (global.config.verbose) {
+                console.log('\nStopped container'.green);
+            }
 
-			finishedCallback();
-		} else {
-			console.error(('\nCould not stop container: ' + containerId).red);
-			process.exit(1);
-		}
-	});
+            finishedCallback();
+        } else {
+            console.error(('\nCould not stop container: ' + containerId).red);
+            process.exit(1);
+        }
+    });
+*/
 
-	return stop;
+    return stop;
 };
 
 /**
@@ -262,21 +332,34 @@ Container.prototype.stopContainer = function(options, containerId, finishedCallb
  * @param finishedCallback
  */
 Container.prototype.removeContainer = function(options, containerId, finishedCallback) {
-	var remove = spawn('docker', ['rm', '-v', containerId], options).on('exit', function(code) {
+    var remove = this.docker.rm(function(err, output){
+        if(err){
+            console.error(('\nCould not remove container: ' + containerId).red);
+            return process.exit(1);
+        }
+        if (global.config.verbose) {
+            console.log('\nRemoved container'.green);
+        }
 
-		if (0 === code) {
-			if (global.config.verbose) {
-				console.log('\nRemoved container'.green);
-			}
+        finishedCallback();
+    });
+    /*
+    var remove = spawn('docker', ['rm', '-v', containerId], options).on('exit', function(code) {
 
-			finishedCallback();
-		} else {
-			console.error(('\nCould not remove container: ' + containerId).red);
-			process.exit(1);
-		}
-	});
+        if (0 === code) {
+            if (global.config.verbose) {
+                console.log('\nRemoved container'.green);
+            }
 
-	return remove;
+            finishedCallback();
+        } else {
+            console.error(('\nCould not remove container: ' + containerId).red);
+            process.exit(1);
+        }
+    });
+    */
+
+    return remove;
 };
 
 /**
@@ -285,73 +368,79 @@ Container.prototype.removeContainer = function(options, containerId, finishedCal
  * @param finishedCallback
  */
 Container.prototype.run = function(finishedCallback) {
-	var self = this,
-		options = {};
+    var self = this,
+        options = {};
 
-	if (global.config.verbose) {
-		options = { stdio: 'inherit' };
-	}
+    if (global.config.verbose) {
+        options = { stdio: 'inherit' };
+        self.docker.on('stderr', function(str){
+            console.error(str);
+        });
+        self.docker.on('stdout', function(str){
+            console.error(str);
+        });
+    }
 
-	console.log(('\nTesting on container ' + self.prettyName + '').green);
+    console.log(('\nTesting on container ' + self.prettyName + '').green);
 
-	self.pullImage(options, function() {
+    self.pullImage(options, function() {
 
-		self.startAndMountContainer({}, function(containerId) {
+        self.startAndMountContainer({}, function(containerId) {
 
-			self.backupFiles({}, containerId, function() {
+            self.createWorkingCopy({}, containerId, function() {
 
-				if (self.beforeScripts && self.beforeScripts.length) {
+                if (self.beforeScripts && self.beforeScripts.length) {
 
-					self.runBeforeScripts(options, containerId, function(code) {
+                    self.runBeforeScripts(options, containerId, function(code) {
 
-						if (code !== 0) {
-							self.cleanupFiles({}, containerId, function() {
+                        if (code !== 0) {
+                            self.cleanupFiles({}, containerId, function() {
 
-								self.stopContainer({}, containerId, function() {
+                                self.stopContainer({}, containerId, function() {
 
-									self.removeContainer({}, containerId, function() {
+                                    self.removeContainer({}, containerId, function() {
 
-										finishedCallback(code);
+                                        finishedCallback(code);
 
-									});
-								});
-							});
-						} else {
-							self.runTests({ stdio: 'inherit' }, containerId, function(code) {
+                                    });
+                                });
+                            });
+                        } else {
+                            self.runTests({ stdio: 'inherit' }, containerId, function(code) {
 
-								self.cleanupFiles({}, containerId, function() {
+                                self.cleanupFiles({}, containerId, function() {
 
-									self.stopContainer({}, containerId, function() {
+                                    self.stopContainer({}, containerId, function() {
 
-										self.removeContainer({}, containerId, function() {
+                                        self.removeContainer({}, containerId, function() {
 
-											finishedCallback(code);
+                                            finishedCallback(code);
 
-										});
-									});
-								});
-							});
-						}
-					});
-				} else {
-					self.runTests({ stdio: 'inherit' }, containerId, function(code) {
+                                        });
+                                    });
+                                });
+                            });
+                        }
+                    });
+                } else {
+                    self.runTests({ stdio: 'inherit' }, containerId, function(code) {
 
-						self.cleanupFiles({}, containerId, function() {
+                        self.cleanupFiles({}, containerId, function() {
 
-							self.stopContainer({}, containerId, function() {
+                            self.stopContainer({}, containerId, function() {
 
-								self.removeContainer({}, containerId, function() {
+                                self.removeContainer({}, containerId, function() {
 
-									finishedCallback(code);
+                                    finishedCallback(code);
 
-								});
-							});
-						});
-					});
-				}
-			});
-		});
-	});
+                                });
+                            });
+                        });
+                    });
+                }
+            });
+        });
+    });
 };
 
 

--- a/lib/container.js
+++ b/lib/container.js
@@ -3,6 +3,7 @@
 var spawn = require('child_process').spawn;
 var colors = require('colors');
 var Docker = require('rouster').Docker;
+var async = require('async');
 
 var reformCommand = function(cmd){
     return cmd.match(/"[^"]+"|'[^']+'|[^ \t]+/g);
@@ -32,7 +33,7 @@ var Container = function(containerArray) {
  *
  * @param finishedCallback
  */
-Container.prototype.pullImage = function(options, finishedCallback) {
+Container.prototype.pullImage = function(finishedCallback) {
     var self = this;
 
     if (global.config.verbose) {
@@ -42,179 +43,105 @@ Container.prototype.pullImage = function(options, finishedCallback) {
     var pull = this.docker.pull(function(err, output){
         if(err){
             console.error(('\nCould not pull Docker image: ' + self.image).red);
+            if(err && err.all){
+                console.error(err.all.join(''));
+            }
             return process.exit(1);
         }
-        finishedCallback();
+        return finishedCallback(null, output);
     });
-/*
-    var pull = spawn('docker', ['pull', this.image], options);
-
-    pull.on('exit', function(code) {
-        if (0 === code) {
-            finishedCallback();
-        } else {
-            console.error(('\nCould not pull Docker image: ' + self.image).red);
-            process.exit(1);
-        }
-    });
-*/
     return pull;
 };
 
 /**
  * Start and mount Docker container
  *
- * @param options
  * @param finishedCallback
  */
-Container.prototype.startAndMountContainer = function(options, finishedCallback) {
+Container.prototype.startAndMountContainer = function(finishedCallback) {
     var self = this;
-    return self.docker.run(self.shellCommand, '-v', global.config.path + ':/app/src', '-w', '/app/test', function(err){
+    return self.docker.run(self.shellCommand, '-v', global.config.path + ':/app/src', '-w', '/app/test', function(err, output){
         if(err){
             console.error('\nFailed to start and mount Docker container'.red);
+            if(err && err.all){
+                console.error(err.all.join(''));
+            }
             return process.exit(1);
         }
-        finishedCallback(self.docker.containerId);
+        return finishedCallback(null, output);
     });
-/*
-    var containerId,
-        self = this,
-        run = spawn('docker', ['run', '-d', '-v', global.config.path + ':/app/test', '-w', '/app/test', '-it', self.image, '/bin/bash']);
-
-    // Dump errors to the stderr output so they can be seen.
-    run.stderr.on('data', function(data) {
-        console.error('ERROR: ', data.toString());
-        console.error('COMMAND: ', 'docker', 'run', '-d', '-v', global.config.path + ':/app/test', '-w', '/app/test', '-it', self.image, '/bin/bash');
-    });
-
-    // Sanitize and store container ID
-    run.stdout.on('data', function(data) {
-        containerId = data.toString().trim().replace(/[^a-z0-9]/ig, '');
-    });
-
-    run.on('exit', function(code) {
-        if (0 !== code || !containerId) {
-            console.error('\nFailed to start and mount Docker container'.red);
-            process.exit(1);
-        }
-
-        finishedCallback(containerId);
-    });
-    return run;
-*/
 };
 
 /**
  * Create a copy of mounted files for testing
  *
- * @param options
- * @param containerId
  * @param finishedCallback
  */
-Container.prototype.createWorkingCopy = function(options, containerId, finishedCallback) {
+Container.prototype.createWorkingCopy = function(finishedCallback) {
 
     if (global.config.verbose) {
-        console.log(('\nBacking up volume files on container ' + this.prettyName).green);
+        console.log(('\nCreating working directory on container ' + this.prettyName).green);
     }
 
     var exec = this.docker.exec('cp', '-R', '/app/src/.', '/app/test', function(err, output){
         if(err){
             console.error('\nFailed to create working copy'.red);
-            return process.exit(1);
+            if(err && err.all){
+                console.error(err.all.join(''));
+            }
+            return finishedCallback(err);
         }
-        finishedCallback(output.code);
+        return finishedCallback(null, output);
     });
-/*
-    var exec = spawn('sh', ['-c', 'docker exec ' + containerId + ' bash + -c "source ~/.bashrc && cp -p -r /app/test /app/backup"']).on('exit', function(code) {
-        if (code !== 0) {
-            console.error('\nFailed to backup up files'.red);
-        }
-
-        finishedCallback(code);
-    });
-
-    return exec;
-*/
 };
 
 /**
  * Run specific before script
  *
- * @param options
  * @param index
- * @param containerId
  * @param finishedCallback
  */
-Container.prototype.runBeforeScript = function(options, index, containerId, finishedCallback) {
+Container.prototype.runBeforeScript = function(script, finishedCallback) {
     var self = this;
-    self.docker.exec(reformCommand(self.beforeScripts[index]), function(err, output){
+    return self.docker.exec(reformCommand(script), function(err, output){
         if(err){
-            console.error(('\nFailed to run before script: ' + self.beforeScripts[index]).red);
-            return process.exit(1);
+            console.error(('\nFailed to run before script: ' + script).red);
+            if(err && err.all){
+                console.error(err.all.join(''));
+            }
+            return finishedCallback(err);
         }
-        finishedCallback(index+1, containerId, output.code);
+        return finishedCallback(null, output);
     });
-
-    /*
-    spawn('sh', ['-c', 'docker exec ' + containerId + ' ' + self.beforeScripts[index]], options).on('exit', function(code) {
-        if (0 !== code) {
-            console.error(('\nFailed to run before script: ' + self.beforeScripts[index]).red);
-        }
-
-        index++;
-
-        finishedCallback(index, containerId, code);
-    });
-    */
 };
 
 /**
  * Run before scripts for container
  *
- * @param options
- * @param containerId
  * @param finishedCallback
  */
-Container.prototype.runBeforeScripts = function(options, containerId, finishedCallback) {
+Container.prototype.runBeforeScripts = function(finishedCallback) {
     var self = this;
-
-    options = { stdio: ['ignore', 'ignore', 'ignore'] };
-
-    if (global.config.verbose > 1) {
-        options = { stdio: 'inherit' };
-    }
 
     if (global.config.verbose) {
         console.log('\nRunning before scripts'.green);
     }
 
     if (!self.beforeScripts.length) {
-        finishedCallback(0);
+        return finishedCallback();
     }
 
-    var nextCallback = function(newIndex, containerId, code) {
-        if (code !== 0) {
-            finishedCallback(1, newIndex);
-        } else {
-            if (newIndex === self.beforeScripts.length) {
-                finishedCallback(code, newIndex);
-            } else {
-                self.runBeforeScript(options, newIndex, containerId, nextCallback);
-            }
-        }
-    };
-
-    self.runBeforeScript(options, 0, containerId, nextCallback);
+    return async.eachSeries(self.beforeScripts, function(script, next){
+        self.runBeforeScript(script, next);
+    }, finishedCallback);
 };
 
 /**
  * Run unit tests for container
  *
- * @param options
- * @param containerId
  * @param finishedCallback
  */
-Container.prototype.runTests = function(options, containerId, finishedCallback) {
+Container.prototype.runTests = function(finishedCallback) {
     var self = this,
         testArgString = '';
 
@@ -226,10 +153,11 @@ Container.prototype.runTests = function(options, containerId, finishedCallback) 
         if ('_' !== key) {
             if (typeof global.testArgs[key] !== 'boolean') {
                 testArgString += ' --' + key + '=' + global.testArgs[key];
-            } else {
-                if (global.testArgs[key]) {
-                    testArgString += ' --' + key;
-                }
+                continue;
+            }
+            if (global.testArgs[key]) {
+                testArgString += ' --' + key;
+                continue;
             }
         }
     }
@@ -238,89 +166,42 @@ Container.prototype.runTests = function(options, containerId, finishedCallback) 
         console.log(('\nRunning "' + self.testCommand + testArgString + '" on container '+ self.prettyName).green);
     }
 
-    /*
-    var exec = spawn('sh', ['-c', 'docker exec ' + containerId + ' bash + -c "source ~/.bashrc && ' + self.testCommand + ' ' + testArgString + ' " 1>&2'], { stdio: 'inherit' }).on('exit', function(code) {
-        if (code !== 0) {
-            console.error('\nFailed to run test command'.red);
-        }
-
-        finishedCallback(code);
-    });
-    */
-    var exec = self.docker.exec(reformCommand(self.testCommand), function(err, output){
+    var exec = self.docker.exec(reformCommand(self.testCommand + testArgString), function(err, output){
         if(err){
             console.error('\nFailed to run test command'.red);
-            return finishedCallback(err.code);
+            if(err && err.all){
+                console.error(err.all.join(''));
+            }
+            return finishedCallback(err);
         }
-        finishedCallback(output.code);
+        return finishedCallback(null, output);
     });
 
     return exec;
 };
 
-
-/**
- * Clean up volume files in container
- *
- * @param options
- * @param containerId
- * @param finishedCallback
- */
-Container.prototype.cleanupFiles = function(options, containerId, finishedCallback) {
-// No longer needed since we create a working copy to deal with instead of dirtying the local disk
-    return finishedCallback(0);
-/*
-    if (global.config.verbose) {
-        console.log(('\nRestoring volume files on container ' + this.prettyName).green);
-    }
-
-    var exec = spawn('sh', ['-c', 'docker exec ' + containerId + ' bash + -c "source ~/.bashrc && rm -rf /app/test/* && cp -p -r /app/backup/* /app/test " 1>&2'], { stdio: 'inherit' }).on('exit', function(code) {
-        if (code !== 0) {
-            console.error('\nFailed to restore volume files'.red);
-        }
-
-        finishedCallback(code);
-    });
-
-    return exec;
-    */
-};
 
 /**
  * Stop Docker container
  *
- * @param options
- * @param containerId
  * @param finishedCallback
  */
-Container.prototype.stopContainer = function(options, containerId, finishedCallback) {
+Container.prototype.stopContainer = function(finishedCallback) {
     var self = this;
 
     var stop = self.docker.stop(function(err, output){
         if(err){
             console.error(('\nCould not stop container: ' + containerId).red);
-            return process.exit(1);
+            if(err && err.all){
+                console.error(err.all.join(''));
+            }
+            return finishedCallback(err);
         }
         if (global.config.verbose) {
             console.log('\nStopped container'.green);
         }
-        finishedCallback();
+        return finishedCallback(null, output);
     });
-/*
-    var stop = spawn('docker', ['stop', containerId], options).on('exit', function(code) {
-        if (0 === code) {
-            if (global.config.verbose) {
-                console.log('\nStopped container'.green);
-            }
-
-            finishedCallback();
-        } else {
-            console.error(('\nCould not stop container: ' + containerId).red);
-            process.exit(1);
-        }
-    });
-*/
-
     return stop;
 };
 
@@ -331,33 +212,21 @@ Container.prototype.stopContainer = function(options, containerId, finishedCallb
  * @param containerId
  * @param finishedCallback
  */
-Container.prototype.removeContainer = function(options, containerId, finishedCallback) {
+Container.prototype.removeContainer = function(finishedCallback) {
     var remove = this.docker.rm(function(err, output){
         if(err){
             console.error(('\nCould not remove container: ' + containerId).red);
-            return process.exit(1);
+            if(err && err.all){
+                console.error(err.all.join(''));
+            }
+            return finishedCallback(err);
         }
         if (global.config.verbose) {
             console.log('\nRemoved container'.green);
         }
 
-        finishedCallback();
+        return finishedCallback(null, output);
     });
-    /*
-    var remove = spawn('docker', ['rm', '-v', containerId], options).on('exit', function(code) {
-
-        if (0 === code) {
-            if (global.config.verbose) {
-                console.log('\nRemoved container'.green);
-            }
-
-            finishedCallback();
-        } else {
-            console.error(('\nCould not remove container: ' + containerId).red);
-            process.exit(1);
-        }
-    });
-    */
 
     return remove;
 };
@@ -377,70 +246,49 @@ Container.prototype.run = function(finishedCallback) {
             console.error(str);
         });
         self.docker.on('stdout', function(str){
-            console.error(str);
+            console.log(str);
         });
     }
 
     console.log(('\nTesting on container ' + self.prettyName + '').green);
 
-    self.pullImage(options, function() {
+    var newStep = function(stepName){
+        return function(callback){
+            return self[stepName](callback);
+        };
+    };
 
-        self.startAndMountContainer({}, function(containerId) {
-
-            self.createWorkingCopy({}, containerId, function() {
-
-                if (self.beforeScripts && self.beforeScripts.length) {
-
-                    self.runBeforeScripts(options, containerId, function(code) {
-
-                        if (code !== 0) {
-                            self.cleanupFiles({}, containerId, function() {
-
-                                self.stopContainer({}, containerId, function() {
-
-                                    self.removeContainer({}, containerId, function() {
-
-                                        finishedCallback(code);
-
-                                    });
-                                });
-                            });
-                        } else {
-                            self.runTests({ stdio: 'inherit' }, containerId, function(code) {
-
-                                self.cleanupFiles({}, containerId, function() {
-
-                                    self.stopContainer({}, containerId, function() {
-
-                                        self.removeContainer({}, containerId, function() {
-
-                                            finishedCallback(code);
-
-                                        });
-                                    });
-                                });
-                            });
-                        }
-                    });
-                } else {
-                    self.runTests({ stdio: 'inherit' }, containerId, function(code) {
-
-                        self.cleanupFiles({}, containerId, function() {
-
-                            self.stopContainer({}, containerId, function() {
-
-                                self.removeContainer({}, containerId, function() {
-
-                                    finishedCallback(code);
-
-                                });
-                            });
-                        });
-                    });
-                }
-            });
+    var cleanup = function(testsError){
+        var cleanupSteps = [
+            newStep('stopContainer'),
+            newStep('removeContainer'),
+        ];
+        async.series(cleanupSteps, function(err){
+            if(testsError){
+                console.error(('\nTesting on container ' + self.prettyName + ' FAILED').red);
+                return finishedCallback(1);
+            }
+            if(err){
+                console.error(('\nTesting on container ' + self.prettyName + ' FAILED').red);
+                return finishedCallback(1);
+            }
+            console.log(('\nTesting on container ' + self.prettyName + ' SUCCESS').green);
+            finishedCallback(0);
         });
-    });
+    };
+
+    var steps = [
+        newStep('pullImage'),
+        newStep('startAndMountContainer'),
+        newStep('createWorkingCopy'),
+    ];
+
+    if (self.beforeScripts && self.beforeScripts.length) {
+        steps.push(newStep('runBeforeScripts'));
+    }
+
+    steps.push(newStep('runTests'));
+    return async.series(steps, cleanup);
 };
 
 

--- a/lib/containers.js
+++ b/lib/containers.js
@@ -14,7 +14,10 @@ var Containers = function(options, containersArray) {
         containersArray = options;
         options = {};
     }
-    this.containerLimit = options.containerLimit || 2;
+    if((options)&&(!containersArray)){
+        containersArray = options.containers || [];
+    }
+    this.containerLimit = options.containerLimit || 1;
     this.containers = containersArray.map(function(config){
         return new Container(config);
     });
@@ -33,23 +36,7 @@ var Containers = function(options, containersArray) {
 Containers.prototype.run = function(finishedCallback, containerId) {
     var self = this,
         returnCodes = [];
-/*
-    var i = 0,
-        self = this,
-        returnCodes = [];
 
-    function callback(code) {
-        i++;
-
-        returnCodes.push(code);
-
-        if (i < self.containers.length) {
-            self.containers[i].run(callback);
-        } else {
-            finishedCallback(returnCodes);
-        }
-    }
-    */
     var runContainer = function(container, next){
         container.run(function(code){
             returnCodes.push(code);
@@ -66,8 +53,6 @@ Containers.prototype.run = function(finishedCallback, containerId) {
             finishedCallback(returnCodes);
         });
         return self;
-    /*} else {
-        self.containers[i].run(callback);*/
     }
     async.eachLimit(self.containers, this.containerLimit, runContainer, done);
     return self;

--- a/lib/containers.js
+++ b/lib/containers.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Container = require('./container').container;
+var async = require('async');
 
 /**
  * Initialize new containers object
@@ -8,42 +9,68 @@ var Container = require('./container').container;
  * @param containersArray
  * @constructor
  */
-var Containers = function(containersArray) {
-	this.containers = [];
+var Containers = function(options, containersArray) {
+    if(Array.isArray(options)){
+        containersArray = options;
+        options = {};
+    }
+    this.containerLimit = options.containerLimit || 2;
+    this.containers = containersArray.map(function(config){
+        return new Container(config);
+    });
+/*
+    this.containers = [];
 
-	for (var i = 0; i < containersArray.length; i++) {
-		this.containers.push(new Container(containersArray[i]));
-	}
+    for (var i = 0; i < containersArray.length; i++) {
+        this.containers.push(new Container(containersArray[i]));
+    }
+*/
 };
 
 /**
  * Run all containers
  */
 Containers.prototype.run = function(finishedCallback, containerId) {
-	var i = 0,
-		self = this,
-		returnCodes = [];
+    var self = this,
+        returnCodes = [];
+/*
+    var i = 0,
+        self = this,
+        returnCodes = [];
 
-	function callback(code) {
-		i++;
+    function callback(code) {
+        i++;
 
-		returnCodes.push(code);
+        returnCodes.push(code);
 
-		if (i < self.containers.length) {
-			self.containers[i].run(callback);
-		} else {
-			finishedCallback(returnCodes);
-		}
-	}
+        if (i < self.containers.length) {
+            self.containers[i].run(callback);
+        } else {
+            finishedCallback(returnCodes);
+        }
+    }
+    */
+    var runContainer = function(container, next){
+        container.run(function(code){
+            returnCodes.push(code);
+            next();
+        });
+    };
+    var done = function(){
+        finishedCallback(returnCodes);
+    };
 
-	if (typeof containerId !== 'undefined' && false !== containerId) {
-		self.containers[containerId].run(function(code) {
-			returnCodes.push(code);
-			finishedCallback(returnCodes);
-		});
-	} else {
-		self.containers[i].run(callback);
-	}
+    if (typeof containerId !== 'undefined' && false !== containerId) {
+        self.containers[containerId].run(function(code) {
+            returnCodes.push(code);
+            finishedCallback(returnCodes);
+        });
+        return self;
+    /*} else {
+        self.containers[i].run(callback);*/
+    }
+    async.eachLimit(self.containers, this.containerLimit, runContainer, done);
+    return self;
 };
 
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
   "author": "Dockunit.io (http://dockunit.io)",
   "license": "GPLv2+",
   "dependencies": {
+    "async": "^2.0.0-rc.1",
     "colors": "^1.0.3",
-    "minimist": "^1.1.0"
+    "minimist": "^1.1.0",
+    "rouster": "0.0.5"
   },
   "keywords": [
     "docker",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dockunit",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Containerized unit testing across any platform and programming language",
   "main": "./lib/command.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dockunit",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Containerized unit testing across any platform and programming language",
   "main": "./lib/command.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "async": "^2.0.0-rc.1",
     "colors": "^1.0.3",
     "minimist": "^1.1.0",
-    "rouster": "0.0.5"
+    "rouster": "^0.0.14"
   },
   "keywords": [
     "docker",

--- a/test/container.js
+++ b/test/container.js
@@ -25,293 +25,250 @@ var oldExit = process.exit;
 
 describe('container', function() {
 
-	describe('#pullImage()', function() {
+    describe('#pullImage()', function() {
 
-		/**
-		 * Test a simple successful Docker image pull
-		 */
-		it('Test successful Docker image pull', function(done) {
-			var json = require('./json/simple-1.json').containers[0];
+        /**
+         * Test a simple successful Docker image pull
+         */
+        it('Test successful Docker image pull', function(done) {
+            var json = require('./json/simple-1.json').containers[0];
 
-			var container = new Container(json);
+            var container = new Container(json);
 
-			mySpawn.setDefault(mySpawn.simple(0));
+            mySpawn.setDefault(mySpawn.simple(0));
 
-			var child = container.pullImage({}, function() {
-				done();
-			});
-		});
+            var child = container.pullImage({}, function() {
+                done();
+            });
+        });
 
-		/**
-		 * Test a simple unsuccessful Docker pull
-		 */
-		it('Test unsuccessful Docker image pull', function(done) {
-			var json = require('./json/simple-1.json').containers[0];
+        /**
+         * Test a simple unsuccessful Docker pull
+         */
+        it('Test unsuccessful Docker image pull', function(done) {
+            var json = require('./json/simple-invalid.json').containers[0];
 
-			var container = new Container(json);
+            var container = new Container(json);
 
-			mySpawn.setDefault(mySpawn.simple(1));
+            mySpawn.setDefault(mySpawn.simple(1));
 
-			process.exit = function(code) {
-				if (1 === code) {
-					done();
-				}
-			};
+            process.exit = function(code) {
+                if (1 === code) {
+                    done();
+                }
+            };
+            container.pullImage({}, function() {});
+        });
 
-			container.pullImage({}, function() {});
-		});
+    });
 
-	});
+    describe('#pullImage()', function() {
 
-	describe('#pullImage()', function() {
+        /**
+         * Test a simple successful Docker image pull
+         */
+        it('Test successful Docker start', function(done) {
+            var json = require('./json/simple-1.json').containers[0];
 
-		/**
-		 * Test a simple successful Docker image pull
-		 */
-		it('Test successful Docker start', function(done) {
-			var json = require('./json/simple-1.json').containers[0];
+            process.exit = oldExit;
 
-			process.exit = oldExit;
+            var container = new Container(json);
 
-			var container = new Container(json);
+            mySpawn.setDefault(mySpawn.simple(0, '24fdgw543ys25'));
 
-			mySpawn.setDefault(mySpawn.simple(0, '24fdgw543ys25'));
+            var child = container.startAndMountContainer({}, function() {
+                done();
+            });
+        });
 
-			var child = container.startAndMountContainer({}, function() {
-				done();
-			});
-		});
+        /**
+         * Test an unsuccessful Docker start where no container ID is provided
+         */
+        it('Test unsuccessful Docker start where no container ID is provided', function(done) {
+            var json = require('./json/simple-invalid.json').containers[0];
 
-		/**
-		 * Test an unsuccessful Docker start where no container ID is provided
-		 */
-		it('Test unsuccessful Docker start where no container ID is provided', function(done) {
-			var json = require('./json/simple-1.json').containers[0];
+            process.exit = oldExit;
 
-			process.exit = oldExit;
+            var container = new Container(json);
 
-			var container = new Container(json);
+            mySpawn.setDefault(mySpawn.simple(0));
 
-			mySpawn.setDefault(mySpawn.simple(0));
+            process.exit = function(code) {
+                if (1 === code) {
+                    done();
+                }
+            };
 
-			process.exit = function(code) {
-				if (1 === code) {
-					done();
-				}
-			};
+            var child = container.startAndMountContainer({}, function() { });
+        });
 
-			var child = container.startAndMountContainer({}, function() { });
-		});
+        /**
+         * Test an unsuccessful Docker start where no container ID is provided
+         */
+        it('Test unsuccessful Docker start the command errored', function(done) {
+            var json = require('./json/simple-invalid.json').containers[0];
 
-		/**
-		 * Test an unsuccessful Docker start where no container ID is provided
-		 */
-		it('Test unsuccessful Docker start the command errored', function(done) {
-			var json = require('./json/simple-1.json').containers[0];
+            process.exit = oldExit;
 
-			process.exit = oldExit;
+            var container = new Container(json);
 
-			var container = new Container(json);
+            mySpawn.setDefault(mySpawn.simple(1));
 
-			mySpawn.setDefault(mySpawn.simple(1));
+            process.exit = function(code) {
+                if (1 === code) {
+                    done();
+                }
+            };
 
-			process.exit = function(code) {
-				if (1 === code) {
-					done();
-				}
-			};
+            var child = container.startAndMountContainer({}, function() { });
+        });
+    });
 
-			var child = container.startAndMountContainer({}, function() { });
-		});
-	});
+    describe('#stopContainer()', function() {
 
-	describe('#stopContainer()', function() {
+        /**
+         * Test a simple successful Docker container stop
+         */
+        it('Test successful Docker container stop', function(done) {
+            var json = require('./json/simple-1.json').containers[0];
 
-		/**
-		 * Test a simple successful Docker container stop
-		 */
-		it('Test successful Docker container stop', function(done) {
-			var json = require('./json/simple-1.json').containers[0];
+            process.exit = oldExit;
 
-			process.exit = oldExit;
+            var container = new Container(json);
 
-			var container = new Container(json);
+            mySpawn.setDefault(mySpawn.simple(0));
 
-			mySpawn.setDefault(mySpawn.simple(0));
+            var child = container.stopContainer({}, 'e534rwdfs', function() {
+                done();
+            });
+        });
+    });
 
-			var child = container.stopContainer({}, 'e534rwdfs', function() {
-				done();
-			});
-		});
+    describe('#removeContainer()', function() {
 
-		/**
-		 * Test a simple successful Docker container stop
-		 */
-		it('Test successful Docker container stop', function(done) {
-			var json = require('./json/simple-1.json').containers[0];
+        /**
+         * Test a simple successful Docker container remove
+         */
+        it('Test successful Docker container remove', function(done) {
+            var json = require('./json/simple-1.json').containers[0];
 
-			process.exit = oldExit;
+            process.exit = oldExit;
 
-			var container = new Container(json);
+            var container = new Container(json);
 
-			mySpawn.setDefault(mySpawn.simple(1));
+            mySpawn.setDefault(mySpawn.simple(0));
 
-			process.exit = function(code) {
-				if (1 === code) {
-					done();
-				}
-			};
+            var child = container.removeContainer({}, 'e534rwdfs', function() {
+                done();
+            });
+        });
+    });
 
-			var child = container.stopContainer({}, 'e534rwdfs', function() { });
-		});
-	});
+    describe('#runBeforeScript()', function() {
 
-	describe('#removeContainer()', function() {
+        /**
+         * Test a simple successful before script
+         */
+        it('Test successful before script', function(done) {
+            var json = require('./json/simple-1.json').containers[0];
 
-		/**
-		 * Test a simple successful Docker container remove
-		 */
-		it('Test successful Docker container remove', function(done) {
-			var json = require('./json/simple-1.json').containers[0];
+            process.exit = oldExit;
 
-			process.exit = oldExit;
+            var container = new Container(json);
 
-			var container = new Container(json);
+            mySpawn.setDefault(mySpawn.simple(0));
 
-			mySpawn.setDefault(mySpawn.simple(0));
+            var child = container.runBeforeScript({}, 0, 'e534rwdfs', function() {
+                done();
+            });
+        });
 
-			var child = container.removeContainer({}, 'e534rwdfs', function() {
-				done();
-			});
-		});
+        /**
+         * Test a simple unsuccessful before script
+         */
+        it('Test unsuccessful before script', function(done) {
+            var json = require('./json/simple-1.json').containers[0];
 
-		/**
-		 * Test a simple successful Docker container remove
-		 */
-		it('Test successful Docker container remove', function(done) {
-			var json = require('./json/simple-1.json').containers[0];
+            var container = new Container(json);
 
-			process.exit = oldExit;
+            mySpawn.setDefault(mySpawn.simple(1));
 
-			var container = new Container(json);
+            var child = container.runBeforeScript({}, 0, 'e534rwdfs', function(code) {
+                if (1 === code) {
+                    done();
+                }
+            });
+        });
 
-			mySpawn.setDefault(mySpawn.simple(1));
+        /**
+         * Test a simple unsuccessful before scripts
+         */
+        it('Test unsuccessful before scripts', function(done) {
+            var json = require('./json/simple-1.json').containers[0];
 
-			process.exit = function(code) {
-				if (1 === code) {
-					done();
-				}
-			};
+            var container = new Container(json);
 
-			var child = container.removeContainer({}, 'e534rwdfs', function() { });
-		});
-	});
+            mySpawn.setDefault(mySpawn.simple(1));
 
-	describe('#runBeforeScript()', function() {
+            var child = container.runBeforeScripts({}, 'e534rwdfs', function(code, index) {
+                assert.equal(1, index); // Only one before script ran
 
-		/**
-		 * Test a simple successful before script
-		 */
-		it('Test successful before script', function(done) {
-			var json = require('./json/simple-1.json').containers[0];
+                done();
+            });
+        });
+    });
 
-			process.exit = oldExit;
+    describe('#runTests()', function() {
 
-			var container = new Container(json);
+        /**
+         * Test a simple passed tests
+         */
+        it('Test passed tests', function(done) {
+            var json = require('./json/simple-1.json').containers[0];
 
-			mySpawn.setDefault(mySpawn.simple(0));
+            process.exit = oldExit;
 
-			var child = container.runBeforeScript({}, 0, 'e534rwdfs', function() {
-				done();
-			});
-		});
+            var container = new Container(json);
 
-		/**
-		 * Test a simple unsuccessful before script
-		 */
-		it('Test unsuccessful before script', function(done) {
-			var json = require('./json/simple-1.json').containers[0];
+            mySpawn.setDefault(mySpawn.simple(0));
 
-			var container = new Container(json);
+            var child = container.runBeforeScript({}, 0, 'e534rwdfs', function() {
+                done();
+            });
+        });
 
-			mySpawn.setDefault(mySpawn.simple(1));
+        /**
+         * Test a simple failed tests
+         */
+        it('Test failed tests', function(done) {
+            var json = require('./json/simple-1.json').containers[0];
 
-			var child = container.runBeforeScript({}, 0, 'e534rwdfs', function(code) {
-				if (1 === code) {
-					done();
-				}
-			});
-		});
+            process.exit = oldExit;
 
-		/**
-		 * Test a simple unsuccessful before scripts
-		 */
-		it('Test unsuccessful before scripts', function(done) {
-			var json = require('./json/simple-1.json').containers[0];
+            var container = new Container(json);
 
-			var container = new Container(json);
+            mySpawn.setDefault(mySpawn.simple(0));
 
-			mySpawn.setDefault(mySpawn.simple(1));
+            var child = container.runTests({}, 'e534rwdfs', function() {
+                done();
+            });
+        });
 
-			var child = container.runBeforeScripts({}, 'e534rwdfs', function(code, index) {
-				assert.equal(1, index); // Only one before script ran
+        /**
+         * Test a simple test error
+         */
+        it('Test test error', function(done) {
+            var json = require('./json/simple-1.json').containers[0];
 
-				done();
-			});
-		});
-	});
+            var container = new Container(json);
 
-	describe('#runTests()', function() {
+            mySpawn.setDefault(mySpawn.simple(255));
 
-		/**
-		 * Test a simple passed tests
-		 */
-		it('Test passed tests', function(done) {
-			var json = require('./json/simple-1.json').containers[0];
-
-			process.exit = oldExit;
-
-			var container = new Container(json);
-
-			mySpawn.setDefault(mySpawn.simple(0));
-
-			var child = container.runBeforeScript({}, 0, 'e534rwdfs', function() {
-				done();
-			});
-		});
-
-		/**
-		 * Test a simple failed tests
-		 */
-		it('Test failed tests', function(done) {
-			var json = require('./json/simple-1.json').containers[0];
-
-			process.exit = oldExit;
-
-			var container = new Container(json);
-
-			mySpawn.setDefault(mySpawn.simple(0));
-
-			var child = container.runTests({}, 'e534rwdfs', function() {
-				done();
-			});
-		});
-
-		/**
-		 * Test a simple test error
-		 */
-		it('Test test error', function(done) {
-			var json = require('./json/simple-1.json').containers[0];
-
-			var container = new Container(json);
-
-			mySpawn.setDefault(mySpawn.simple(255));
-
-			var child = container.runTests({}, 'e534rwdfs', function(code) {
-				if (code > 1) {
-					done();
-				}
-			});
-		});
-	});
+            var child = container.runTests({}, 'e534rwdfs', function(code) {
+                if (code > 1) {
+                    done();
+                }
+            });
+        });
+    });
 });

--- a/test/container.js
+++ b/test/container.js
@@ -4,17 +4,18 @@
 
 var proxyquire = require('proxyquire');
 var assert = require('assert');
-var mockSpawn = require('mock-spawn');
+//var mockSpawn = require('mock-spawn');
 var command = require('../lib/command');
 
-var mySpawn = mockSpawn();
+//var mySpawn = mockSpawn();
 
 /**
  * Mock the spawn dependency
  *
  * @type {container|exports.container}
  */
-var Container = proxyquire('../lib/container', { child_process: { spawn: mySpawn } }).container;
+//var Container = proxyquire('../lib/container', { child_process: { spawn: mySpawn } }).container;
+var Container = require('../lib/container').container;
 
 /**
  * Mock config
@@ -35,9 +36,9 @@ describe('container', function() {
 
             var container = new Container(json);
 
-            mySpawn.setDefault(mySpawn.simple(0));
+            //mySpawn.setDefault(mySpawn.simple(0));
 
-            var child = container.pullImage({}, function() {
+            var child = container.pullImage(function() {
                 done();
             });
         });
@@ -50,14 +51,14 @@ describe('container', function() {
 
             var container = new Container(json);
 
-            mySpawn.setDefault(mySpawn.simple(1));
+            //mySpawn.setDefault(mySpawn.simple(1));
 
             process.exit = function(code) {
-                if (1 === code) {
+                if (code === 1) {
                     done();
                 }
             };
-            container.pullImage({}, function() {});
+            container.pullImage(function() {});
         });
 
     });
@@ -74,9 +75,9 @@ describe('container', function() {
 
             var container = new Container(json);
 
-            mySpawn.setDefault(mySpawn.simple(0, '24fdgw543ys25'));
+            //mySpawn.setDefault(mySpawn.simple(0, '24fdgw543ys25'));
 
-            var child = container.startAndMountContainer({}, function() {
+            var child = container.startAndMountContainer(function() {
                 done();
             });
         });
@@ -91,15 +92,15 @@ describe('container', function() {
 
             var container = new Container(json);
 
-            mySpawn.setDefault(mySpawn.simple(0));
+            //mySpawn.setDefault(mySpawn.simple(0));
 
             process.exit = function(code) {
-                if (1 === code) {
+                if (code === 1) {
                     done();
                 }
             };
 
-            var child = container.startAndMountContainer({}, function() { });
+            var child = container.startAndMountContainer(function() { });
         });
 
         /**
@@ -112,15 +113,15 @@ describe('container', function() {
 
             var container = new Container(json);
 
-            mySpawn.setDefault(mySpawn.simple(1));
+            //mySpawn.setDefault(mySpawn.simple(1));
 
             process.exit = function(code) {
-                if (1 === code) {
+                if (code === 1) {
                     done();
                 }
             };
 
-            var child = container.startAndMountContainer({}, function() { });
+            var child = container.startAndMountContainer(function() { });
         });
     });
 
@@ -136,9 +137,9 @@ describe('container', function() {
 
             var container = new Container(json);
 
-            mySpawn.setDefault(mySpawn.simple(0));
+            //mySpawn.setDefault(mySpawn.simple(0));
 
-            var child = container.stopContainer({}, 'e534rwdfs', function() {
+            var child = container.stopContainer(function() {
                 done();
             });
         });
@@ -156,9 +157,9 @@ describe('container', function() {
 
             var container = new Container(json);
 
-            mySpawn.setDefault(mySpawn.simple(0));
+            //mySpawn.setDefault(mySpawn.simple(0));
 
-            var child = container.removeContainer({}, 'e534rwdfs', function() {
+            var child = container.removeContainer(function() {
                 done();
             });
         });
@@ -176,9 +177,9 @@ describe('container', function() {
 
             var container = new Container(json);
 
-            mySpawn.setDefault(mySpawn.simple(0));
+            //mySpawn.setDefault(mySpawn.simple(0));
 
-            var child = container.runBeforeScript({}, 0, 'e534rwdfs', function() {
+            var child = container.runBeforeScript(json.beforeScripts[0], function() {
                 done();
             });
         });
@@ -191,10 +192,10 @@ describe('container', function() {
 
             var container = new Container(json);
 
-            mySpawn.setDefault(mySpawn.simple(1));
+            //mySpawn.setDefault(mySpawn.simple(1));
 
-            var child = container.runBeforeScript({}, 0, 'e534rwdfs', function(code) {
-                if (1 === code) {
+            var child = container.runBeforeScript(json.beforeScripts[0], function(err) {
+                if (err) {
                     done();
                 }
             });
@@ -208,12 +209,12 @@ describe('container', function() {
 
             var container = new Container(json);
 
-            mySpawn.setDefault(mySpawn.simple(1));
+            //mySpawn.setDefault(mySpawn.simple(1));
 
-            var child = container.runBeforeScripts({}, 'e534rwdfs', function(code, index) {
-                assert.equal(1, index); // Only one before script ran
-
-                done();
+            var child = container.runBeforeScripts(function(err) {
+                if(err){
+                    done();
+                }
             });
         });
     });
@@ -230,9 +231,9 @@ describe('container', function() {
 
             var container = new Container(json);
 
-            mySpawn.setDefault(mySpawn.simple(0));
+            //mySpawn.setDefault(mySpawn.simple(0));
 
-            var child = container.runBeforeScript({}, 0, 'e534rwdfs', function() {
+            var child = container.runBeforeScript(json.beforeScripts[0], function() {
                 done();
             });
         });
@@ -247,9 +248,9 @@ describe('container', function() {
 
             var container = new Container(json);
 
-            mySpawn.setDefault(mySpawn.simple(0));
+            //mySpawn.setDefault(mySpawn.simple(0));
 
-            var child = container.runTests({}, 'e534rwdfs', function() {
+            var child = container.runTests(function() {
                 done();
             });
         });
@@ -262,10 +263,10 @@ describe('container', function() {
 
             var container = new Container(json);
 
-            mySpawn.setDefault(mySpawn.simple(255));
+            //mySpawn.setDefault(mySpawn.simple(255));
 
-            var child = container.runTests({}, 'e534rwdfs', function(code) {
-                if (code > 1) {
+            var child = container.runTests(function(err) {
+                if (err && (err.toString() === 'Error: Not connected')) {
                     done();
                 }
             });

--- a/test/containers.js
+++ b/test/containers.js
@@ -22,90 +22,90 @@ var oldExit = process.exit;
 
 describe('containers', function() {
 
-	describe('#run()', function() {
+    describe('#run()', function() {
 
-		/**
-		 * Test all successful containers
-		 */
-		it('Test all successful containers', function(done) {
-			var json = require('./json/multiple-1.json');
+        /**
+         * Test all successful containers
+         */
+        it('Test all successful containers', function(done) {
+            var json = require('./json/multiple-1.json');
 
-			var containers = new Containers(json.containers);
+            var containers = new Containers(json.containers);
 
-			mockContainer.prototype.run = function(finishedCallback) {
-				finishedCallback(0);
-			};
+            mockContainer.prototype.run = function(finishedCallback) {
+                finishedCallback(0);
+            };
 
-			containers.run(function(returnCodes) {
-				assert.equal(returnCodes.length, 2);
-				assert.equal(returnCodes.join(''), '00');
+            containers.run(function(returnCodes) {
+                assert.equal(returnCodes.length, 2);
+                assert.equal(returnCodes.join(''), '00');
 
-				done();
-			});
-		});
+                done();
+            });
+        });
 
-		/**
-		 * Test with one unsuccessful containers
-		 */
-		it('Test with one unsuccessful container', function(done) {
-			var json = require('./json/multiple-1.json');
+        /**
+         * Test with one unsuccessful containers
+         */
+        it('Test with one unsuccessful container', function(done) {
+            var json = require('./json/multiple-1.json');
 
-			var containers = new Containers(json.containers);
+            var containers = new Containers(json.containers);
 
-			var returnCode = 0;
+            var returnCode = 0;
 
-			mockContainer.prototype.run = function(finishedCallback) {
-				finishedCallback(returnCode++);
-			};
+            mockContainer.prototype.run = function(finishedCallback) {
+                finishedCallback(returnCode++);
+            };
 
-			containers.run(function(returnCodes) {
-				assert.equal(returnCodes.length, 2);
-				assert.equal(returnCodes.join(''), '01');
+            containers.run(function(returnCodes) {
+                assert.equal(returnCodes.length, 2);
+                assert.equal(returnCodes.join(''), '01');
 
-				done();
-			});
-		});
+                done();
+            });
+        });
 
-		/**
-		 * Run one container only
-		 */
-		it('Run specific container', function(done) {
-			var json = require('./json/multiple-1.json');
+        /**
+         * Run one container only
+         */
+        it('Run specific container', function(done) {
+            var json = require('./json/multiple-1.json');
 
-			var containers = new Containers(json.containers);
+            var containers = new Containers(json.containers);
 
-			mockContainer.prototype.run = function(finishedCallback) {
-				finishedCallback(0);
-			};
+            mockContainer.prototype.run = function(finishedCallback) {
+                finishedCallback(0);
+            };
 
-			containers.run(function(returnCodes) {
-				assert.equal(returnCodes.length, 1);
-				assert.equal(returnCodes.join(''), '0');
+            containers.run(function(returnCodes) {
+                assert.equal(returnCodes.length, 1);
+                assert.equal(returnCodes.join(''), '0');
 
-				done();
-			}, 1);
-		});
+                done();
+            }, 1);
+        });
 
-		/**
-		 * Run first container only
-		 */
-		it('Run first container', function(done) {
-			var json = require('./json/multiple-1.json');
+        /**
+         * Run first container only
+         */
+        it('Run first container', function(done) {
+            var json = require('./json/multiple-1.json');
 
-			var containers = new Containers(json.containers);
+            var containers = new Containers(json.containers);
 
-			mockContainer.prototype.run = function(finishedCallback) {
-				finishedCallback(0);
-			};
+            mockContainer.prototype.run = function(finishedCallback) {
+                finishedCallback(0);
+            };
 
-			containers.run(function(returnCodes) {
-				assert.equal(returnCodes.length, 1);
-				assert.equal(returnCodes.join(''), '0');
+            containers.run(function(returnCodes) {
+                assert.equal(returnCodes.length, 1);
+                assert.equal(returnCodes.join(''), '0');
 
-				done();
-			}, 0);
-		});
+                done();
+            }, 0);
+        });
 
-	});
+    });
 
 });

--- a/test/json/simple-invalid.json
+++ b/test/json/simple-invalid.json
@@ -1,0 +1,21 @@
+{
+    "containers": [
+        {
+            "prettyName": "PHP-FPM 5.2",
+            "image": "someinvalidcontainer/yeahitfailed",
+            "testCommand": "phpunit",
+            "beforeScripts": [
+                "test",
+                "test2"
+            ]
+        },
+        {
+            "prettyName": "PHP-FPM 5.3",
+            "image": "tlovett1/php-5.3-phpunit-3.5",
+            "testCommand": "phpunit",
+            "beforeScripts": [
+                "test3"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This adds in support for shellCommand (for distros like Alpine that need a different shell command) and containerLimit to allow parallel execution of tests.

Ton's of refactor work in there.  So much that I actually broke out the docker wrapper to its own npm module called rouster then re-wrapped everything back up into a nice package.  Also brings in async to do some of the heavy lifting.

Lots of manual testing done, and I think I got the actual tests right, but there was so much refactor that some may still need to be re-written.

Also, version bump to 0.5.4 included.

Completely backward compatible.

Closes #4, #10, and #11 
